### PR TITLE
Despawn idle police vehicles after prolonged stops

### DIFF
--- a/lua/ge/extensions/gameplay/traffic/roles/police.lua
+++ b/lua/ge/extensions/gameplay/traffic/roles/police.lua
@@ -17,6 +17,7 @@ function C:init()
   self.cooldownTimer = -1
   self.driveInLane = true
   self.validTargets = {}
+  self.stoppedTimer = 0
   self.actions = {
     pursuitStart = function (args)
       local firstMode = 'chase'
@@ -151,6 +152,16 @@ function C:onRefresh()
 end
 
 function C:onTrafficTick(dt)
+  if self.veh.speed > 1.39 or self.flags.pursuit then
+    self.stoppedTimer = 0
+  else
+    self.stoppedTimer = self.stoppedTimer + dt
+    if self.stoppedTimer > 30 then
+      gameplay_traffic.removeTraffic(self.veh.id, true)
+      return
+    end
+  end
+
   for id, veh in pairs(gameplay_traffic.getTrafficData()) do -- update data of potential targets
     if id ~= self.veh.id and veh.role.name ~= 'police' and not veh.ignorePolice and not self.flags.cooldown then
       if not self.validTargets[id] then self.validTargets[id] = {} end


### PR DESCRIPTION
## Summary
- track how long police vehicles remain stopped when not in pursuit
- despawn stranded police vehicles after 30 seconds of inactivity

## Testing
- ⚠️ `luac -p lua/ge/extensions/gameplay/traffic/roles/police.lua` *(missing `luac` command)*
- ⚠️ `apt-get update` *(403 errors prevented installing Lua tools)*

------
https://chatgpt.com/codex/tasks/task_e_689c90e43f5c83299ea90b8412024ebc