### PR TITLE
feat(police): add persistent police spawning

### DIFF
--- a/lua/ge/extensions/career/modules/playerDriving.lua
+++ b/lua/ge/extensions/career/modules/playerDriving.lua
@@ -142,12 +142,11 @@ local function setupTraffic(forceSetup)
       end
     end
 
-    -- police amount and vehicle pooling
+    -- police amount
     local policeAmount = M.debugMode and testTrafficAmounts.police or 2 -- temporarily disabled by default
     if isNoPoliceModActive() then
       policeAmount = 0
     end
-    local extraAmount = policeAmount -- enables traffic pooling
     playerData.trafficActive = restrict and testTrafficAmounts.active or amount -- store the amount here for future usage
     if playerData.trafficActive == 0 then
       playerData.trafficActive = math.huge
@@ -156,11 +155,11 @@ local function setupTraffic(forceSetup)
     -- this will spawn vehicles near the center of the map (player vehicle not ready yet)
     -- if this would wait until player vehicle active, then the loading screen would fade out early...
     gameplay_parking.setupVehicles(restrict and testTrafficAmounts.parkedCars or parkedAmount)
-    gameplay_traffic.setupTraffic(restrict and testTrafficAmounts.traffic + extraAmount or amount + extraAmount, 0, {
-      policeAmount = policeAmount,
+    gameplay_traffic.setupTraffic(restrict and testTrafficAmounts.traffic or amount, 0, {
       simpleVehs = true,
       autoLoadFromFile = true
     })
+    gameplay_police.spawnPersistent(policeAmount)
     setTrafficVars()
 
     M.ensureTraffic = false

--- a/lua/ge/extensions/gameplay/police.lua
+++ b/lua/ge/extensions/gameplay/police.lua
@@ -127,6 +127,19 @@ local function removeProp(propId) -- removes a prop from the props list
   end
 end
 
+local function spawnPersistent(amount)
+  if type(amount) ~= 'number' or amount <= 0 then return end
+
+  local group = gameplay_traffic_trafficUtils.createPoliceGroup(amount)
+  local ids = core_multiSpawn.spawnGroup(group, amount)
+
+  if type(ids) == 'table' then
+    for _, id in ipairs(ids) do
+      gameplay_traffic.insertTraffic(id, false, true)
+    end
+  end
+end
+
 local function resetPursuitVars() -- resets pursuit variables to default
   vars = {
     scoreLevels = deepcopy(defaultScoreLevels),
@@ -773,6 +786,7 @@ end
 -- public interface
 M.insertProp = insertProp
 M.removeProp = removeProp
+M.spawnPersistent = spawnPersistent
 M.setPropsActive = setPropsActive
 M.checkRoadblock = checkRoadblock
 M.placeRoadblock = placeRoadblock


### PR DESCRIPTION
## Summary
- allow persistent police vehicles via new `gameplay_police.spawnPersistent`
- spawn police after traffic setup instead of via traffic pooling

## Testing
- ⚠️ `luacheck lua/ge/extensions/gameplay/police.lua lua/ge/extensions/career/modules/playerDriving.lua` (command not found)
- ⚠️ `luac -p lua/ge/extensions/gameplay/police.lua lua/ge/extensions/career/modules/playerDriving.lua` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_689c9065e21883298bcf85328a160e6c